### PR TITLE
Allow delay between starting LIMS and watching log

### DIFF
--- a/images/baobab/Dockerfile
+++ b/images/baobab/Dockerfile
@@ -93,6 +93,8 @@ VOLUME /data/filestorage /data/blobstorage
 
 COPY docker-initialize.py docker-entrypoint.sh /
 
+# maximum time to wait for LIMS daemon to start, by default 20 seconds
+ENV STARTUP_MAXDELAY=20
 RUN chmod a+x /docker-entrypoint.sh
 
 EXPOSE 8080

--- a/images/baobab/docker-entrypoint.sh
+++ b/images/baobab/docker-entrypoint.sh
@@ -25,6 +25,12 @@ if [[ $START == *"$1"* ]]; then
 
   trap _stop SIGTERM SIGINT
   $CMD start
+  COUNT=0
+  MAXDELAY=${STARTUP_MAXDELAY:-20}
+  while [ $COUNT -lt $MAXDELAY -a ! -f /data/log/instance.log ] ; do
+    sleep 1
+    COUNT=`expr $COUNT + 1`
+  done
   $CMD logtail &
 
   child=$!


### PR DESCRIPTION
When testing Docker deployment of the Baobab-LIMS on a Mac Mini the container failed to start correctly due to a race condition in the docker-entrypoint.sh. This PR adds a configurable delay to avoid that race condition.